### PR TITLE
Increase Keycloak request timeout to 3 seconds

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,7 @@ provider:
     AUTHORIZER_API: ${ssm:/dataplatform/shared/api-gateway-url}/simple-dataset-authorizer
     KEYCLOAK_SERVER: ${ssm:/dataplatform/shared/keycloak-server-url}
     KEYCLOAK_REALM: api-catalog
+    KEYCLOAK_TIMEOUT_MS: 3000
     RESOURCE_SERVER_CLIENT_ID: "okdata-resource-server"
     OKDATA_CLIENT_ID: event-collector
     OKDATA_CLIENT_SECRET: ${ssm:/dataplatform/${self:service.name}/keycloak-client-secret~true}


### PR DESCRIPTION
In an attempt to reduce the number of Keycloak timeout errors we see in production.