### PR TITLE
Set shorter timeouts when calling AWS services

### DIFF
--- a/event_collector/handler.py
+++ b/event_collector/handler.py
@@ -43,7 +43,9 @@ okdata_config = Config()
 okdata_config.config["cacheCredentials"] = False
 webhook_client = WebhookClient(okdata_config)
 
-retry_config = botocore.config.Config(retries={"max_attempts": 3, "mode": "standard"})
+retry_config = botocore.config.Config(
+    connect_timeout=3, read_timeout=3, retries={"max_attempts": 3, "mode": "standard"}
+)
 
 with open("serverless/documentation/schemas/postEventsRequest.json") as f:
     post_events_request_schema = json.loads(f.read())


### PR DESCRIPTION
boto3 default timeout is 60 seconds for connect and read/write. This
is higher than the max 29 second timeout for API Gateway calls to Lambda
functions. Lowering the timeout when calling Kinesis and DynamoDB to
avoid Lambda functions terminating without any error handling or logs.